### PR TITLE
feat: Support Terraform ECS Deployments

### DIFF
--- a/deploy-ecs/deploy.sh
+++ b/deploy-ecs/deploy.sh
@@ -34,15 +34,18 @@ function check_deployment_complete() {
   [ "${pending_count}" -eq "0" ] && [ "${running_count}" -eq "${desired_count}" ]
 }
 
+# set default region so we don't have to specify --region everywhere
+export AWS_DEFAULT_REGION="${AWS_REGION}"
+
 # attempt to get the contents of the template task definition from ECS (for Terraform-built ECS services)
 echo "Retrieving ${ECS_SERVICE}-template task definition..."
-taskdefinition="$(aws ecs describe-task-definition --region "${AWS_REGION}" --task-definition "${ECS_SERVICE}-template")" \
+taskdefinition="$(aws ecs describe-task-definition --task-definition "${ECS_SERVICE}-template")" \
   || echo "No template task definition was found."
 
 # if no template exists, attempt to get task definition currently running on AWS (for legacy ECS services)
 if [ -z "${taskdefinition}" ]; then
   echo "Retreiving current ${ECS_SERVICE} task definition..."
-  taskdefinition=$(aws ecs describe-task-definition --region "${AWS_REGION}" --task-definition "${ECS_SERVICE}")
+  taskdefinition=$(aws ecs describe-task-definition --task-definition "${ECS_SERVICE}")
 fi
 
 # use retrieved task definition as basis for new revision, but replace image

--- a/deploy-ecs/deploy.sh
+++ b/deploy-ecs/deploy.sh
@@ -1,6 +1,19 @@
 #!/bin/bash
 set -e -u
 
+# uncomment to debug
+# set -x
+
+# Update an ECS service and monitor its deployment status.
+# h/t to this blog post for inspriration:
+# https://medium.com/@aaron.kaz.music/monitoring-the-health-of-ecs-service-deployments-baeea41ae737
+
+# required environment variables:
+# - AWS_REGION
+# - ECS_CLUSTER
+# - ECS_SERVICE
+# - DOCKER_TAG
+
 function check_deployment_complete() {
   # extract task counts and test whether they match the desired state
 

--- a/deploy-ecs/deploy.sh
+++ b/deploy-ecs/deploy.sh
@@ -69,7 +69,7 @@ aws ecs register-task-definition \
   --container-definitions "${newcontainers}" \
   --volumes "$(echo "${taskdefinition}" | jq '.taskDefinition.volumes')" \
   --placement-constraints "$(echo "${taskdefinition}" | jq '.taskDefinition.placementConstraints')" \
-  --requires-compatibilities "$(echo "${taskdefinition}" | jq -r '.taskDefinition.requiresCompatibilities[]')" \
+  --requires-compatibilities "$(echo "${taskdefinition}" | jq -r '.taskDefinition.requiresCompatibilities')" \
   --cpu "$(echo "${taskdefinition}" | jq -r '.taskDefinition.cpu')" \
   --memory "$(echo "${taskdefinition}" | jq -r '.taskDefinition.memory')"
 

--- a/deploy-ecs/deploy.sh
+++ b/deploy-ecs/deploy.sh
@@ -1,13 +1,44 @@
 #!/bin/bash
 set -e -u
 
-# get JSON describing task definition currently running on AWS
-# use it as basis for new revision, but replace image with the one built above
-taskdefinition=$(aws ecs describe-task-definition --region us-east-1 --task-definition $ECS_SERVICE)
-taskdefinition=$(echo $taskdefinition | jq ".taskDefinition | del(.status) | del(.taskDefinitionArn) | del(.requiresAttributes) | del(.revision) | del(.compatibilities) | del(.registeredAt) | del(.registeredBy)")
-newcontainers=$(echo $taskdefinition | jq ".containerDefinitions | map(.image=\"$DOCKER_TAG\")")
-aws ecs register-task-definition --region us-east-1 --family $ECS_SERVICE --cli-input-json "$taskdefinition" --container-definitions "$newcontainers"
-newrevision=$(aws ecs describe-task-definition --region $AWS_REGION --task-definition $ECS_SERVICE | jq '.taskDefinition.revision')
+# attempt to get the contents of the template task definition from ECS (for Terraform-built ECS services)
+echo "Retrieving ${ECS_SERVICE}-template task definition..."
+taskdefinition="$(aws ecs describe-task-definition --region "${AWS_REGION}" --task-definition "${ECS_SERVICE}-template")" \
+  || echo "No template task definition was found."
+
+# if no template exists, attempt to get task definition currently running on AWS (for legacy ECS services)
+if [ -z "${taskdefinition}" ]; then
+  echo "Retreiving current ${ECS_SERVICE} task definition..."
+  taskdefinition=$(aws ecs describe-task-definition --region "${AWS_REGION}" --task-definition "${ECS_SERVICE}")
+fi
+
+# use retrieved task definition as basis for new revision, but replace image
+echo "Updating container image to ${DOCKER_TAG}."
+newcontainers="$(echo "${taskdefinition}" | \
+  jq '.taskDefinition.containerDefinitions' | \
+  jq --arg tag "${DOCKER_TAG}" 'map(.image="\($tag)")')"
+
+# check to make sure the secrets are included in the new container definition
+if (echo "${newcontainers}" | jq '.[0] | .secrets' | grep '^null$'); then
+  echo "Error: The container definition is missing its 'secrets' block. Deploy cannot proceed."
+  exit 1
+fi
+
+echo "Publishing new task definition."
+aws ecs register-task-definition \
+  --family "${ECS_SERVICE}" \
+  --task-role-arn "$(echo "${taskdefinition}" | jq -r '.taskDefinition.taskRoleArn')" \
+  --execution-role-arn "$(echo "${taskdefinition}" | jq -r '.taskDefinition.executionRoleArn')" \
+  --network-mode "$(echo "${taskdefinition}" | jq -r '.taskDefinition.networkMode')" \
+  --container-definitions "${newcontainers}" \
+  --volumes "$(echo "${taskdefinition}" | jq '.taskDefinition.volumes')" \
+  --placement-constraints "$(echo "${taskdefinition}" | jq '.taskDefinition.placementConstraints')" \
+  --requires-compatibilities "$(echo "${taskdefinition}" | jq -r '.taskDefinition.requiresCompatibilities[]')" \
+  --cpu "$(echo "${taskdefinition}" | jq -r '.taskDefinition.cpu')" \
+  --memory "$(echo "${taskdefinition}" | jq -r '.taskDefinition.memory')"
+
+newrevision="$(aws ecs describe-task-definition --task-definition "${ECS_SERVICE}" | \
+  jq -r '.taskDefinition.revision')"
 
 function task_count_eq {
     local tasks


### PR DESCRIPTION
Asana Task: [Update ecs-deploy GitHub action to support Terraform-managed ECS services](https://app.asana.com/0/1113179098808463/1200319542968313/f)

## Considerations

- Support pulling task definition data from a "template" task definition, for ECS services provisioned with Terraform. If no template task definition exists, fall back to using the current task definition.
- Use explicit arguments when registering the new task definition instead of `--cli-input-json`
- Track deployment status using the ECS service's "deployment" data
- Use `AWS_DEFAULT_REGION` env var instead of passing the `--region` argument in each `aws` command
- Add comments and documentation

## Tested

Running this script locally, I was able to successfully deploy both `parking-lpr-dev` (template task def) and `concentrate-dev` (current task def).