### PR TITLE
fix: exit with status code 1 if an error is thrown

### DIFF
--- a/dialyzer/dist/main/index.js
+++ b/dialyzer/dist/main/index.js
@@ -59778,7 +59778,10 @@ function run() {
         yield mixDialyzer(_actions_core__WEBPACK_IMPORTED_MODULE_1__.getInput("cmd-line").split(" "));
     });
 }
-run();
+run().catch((e) => {
+    console.error("Dialyzer failed", e);
+    process.exit(1);
+});
 
 })();
 

--- a/dialyzer/src/main.ts
+++ b/dialyzer/src/main.ts
@@ -112,4 +112,7 @@ async function run(): Promise<void> {
   await mixDialyzer(core.getInput("cmd-line").split(" "));
 }
 
-run();
+run().catch((e) => {
+  console.error("Dialyzer failed", e);
+  process.exit(1);
+});


### PR DESCRIPTION
We can't use async/await at the top-level, so we use `Promise.catch` to catch
the error and return a status code of 1.

Fixes #2