### PR TITLE
feat: new helper actions for building ElasticBeanstalk apps

### DIFF
--- a/commit-metadata/action.yml
+++ b/commit-metadata/action.yml
@@ -1,0 +1,24 @@
+name: Commit metadata
+description: Fetch Git metadata for the current SHA
+outputs:
+  sha-short:
+    description: Short Git SHA
+    value: ${{ steps.git.outputs.sha-short }}
+  commit-message:
+    description: Current commit message
+    value: ${{ steps.git.outputs.commit-message }}
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      id: git
+      run: |
+        echo ::set-output name=sha-short::$(git rev-parse --short ${{ github.sha }})
+        echo ::set-output name=commit-message::$(git log --format=%B -n 1 ${{ github.sha }} | head -n 1)
+    - shell: bash
+      run: |
+        cat <<EOF
+        Set outputs:
+        - sha-short => ${{ steps.git.outputs.sha-short }}
+        - commit-message => ${{ steps.git.outputs.commit-message }}
+        EOF

--- a/eb-ecr-dockerrun/action.yml
+++ b/eb-ecr-dockerrun/action.yml
@@ -1,0 +1,43 @@
+name: ElasticBeanstalk ECR Dockerrun.aws.json
+description: Build an ElasticBeanstalk Dockerrun.aws.json based on an AWS ECR tag
+inputs:
+  docker-tag:
+    required: true
+    description: Docker tag to use in the deployment
+  port:
+    description: The port to publish (should be exposed by the Dockerfile)
+    default: 4000
+outputs:
+  deployment-package:
+    description: Path to the deployment .zip file
+    value: ${{ steps.build.outputs.package }}
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      id: build
+      run: |
+        echo ::set-output name=package::$(mktemp -d $RUNNER_TEMP/package-XXXXXX)/${{ github.sha }}.zip
+        echo ::set-output name=dir::$(mktemp -d $RUNNER_TEMP/deploy-XXXXXX)
+    - shell: bash
+      run: |
+        test -d rel/.ebextensions && cp -r rel/.ebextensions ${{ steps.build.outputs.dir }}
+        pushd ${{ steps.build.outputs.dir }} > /dev/null
+        cat <<EOF > Dockerrun.aws.json
+        {
+          "AWSEBDockerrunVersion": "1",
+          "Image": {
+            "Name": "${{ inputs.docker-tag }}",
+            "Update": "true"
+          },
+          "Ports": [
+            {
+              "ContainerPort": "${{ inputs.port }}"
+            }
+          ]
+        }
+        EOF
+        zip -r ${{ steps.build.outputs.package }} .
+        popd > /dev/null
+        rm -rf ${{ steps.build.outputs.dir }}
+        echo Created build package: ${{ steps.build.outputs.package }}


### PR DESCRIPTION
- `commit-metadata` fetches the metadata for generating versions
- `eb-ecr-dockerrun` creates a `Dockerrun.aws.json` .zip package

Successful deploy: https://github.com/paulswartz/api/actions/runs/871470224

Will create the tags post-merge.