### PR TITLE
ci: make check for secrets optional

### DIFF
--- a/deploy-ecs/action.yml
+++ b/deploy-ecs/action.yml
@@ -20,6 +20,10 @@ inputs:
   docker-tag:
     description: Docker tag to deploy
     required: true
+  requires-secrets:
+    description: Whether the service needs secrets
+    required: false
+    default: 'true'
 runs:
   using: composite
   steps:
@@ -32,3 +36,4 @@ runs:
         ECS_CLUSTER: ${{ inputs.ecs-cluster }}
         ECS_SERVICE: ${{ inputs.ecs-service }}
         DOCKER_TAG: ${{ inputs.docker-tag }}
+        REQUIRES_SECRETS: ${{ inputs.requires-secrets }}

--- a/deploy-ecs/action.yml
+++ b/deploy-ecs/action.yml
@@ -21,7 +21,7 @@ inputs:
     description: Docker tag to deploy
     required: true
   requires-secrets:
-    description: Whether the service needs secrets
+    description: Whether the service needs secrets (expects "true" or "false")
     required: false
     default: 'true'
 runs:

--- a/deploy-ecs/deploy.sh
+++ b/deploy-ecs/deploy.sh
@@ -55,7 +55,7 @@ newcontainers="$(echo "${taskdefinition}" | \
   jq --arg tag "${DOCKER_TAG}" 'map(.image="\($tag)")')"
 
 # check to make sure the secrets are included in the new container definition
-if (echo "${newcontainers}" | jq '.[0] | .secrets' | grep '^null$'); then
+if [ "${REQUIRES_SECRETS}" = true ] && (echo "${newcontainers}" | jq '.[0] | .secrets' | grep '^null$'); then
   echo "Error: The container definition is missing its 'secrets' block. Deploy cannot proceed."
   exit 1
 fi

--- a/deploy-ecs/deploy.sh
+++ b/deploy-ecs/deploy.sh
@@ -5,7 +5,7 @@ set -e -u
 # set -x
 
 # Update an ECS service and monitor its deployment status.
-# h/t to this blog post for inspriration:
+# h/t to this blog post for inspiration:
 # https://medium.com/@aaron.kaz.music/monitoring-the-health-of-ecs-service-deployments-baeea41ae737
 
 # required environment variables:
@@ -44,7 +44,7 @@ taskdefinition="$(aws ecs describe-task-definition --task-definition "${ECS_SERV
 
 # if no template exists, attempt to get task definition currently running on AWS (for legacy ECS services)
 if [ -z "${taskdefinition}" ]; then
-  echo "Retreiving current ${ECS_SERVICE} task definition..."
+  echo "Retrieving current ${ECS_SERVICE} task definition..."
   taskdefinition=$(aws ecs describe-task-definition --task-definition "${ECS_SERVICE}")
 fi
 
@@ -85,7 +85,7 @@ deployment_finished=false
 while [ "${deployment_finished}" = "false" ]; do
   # get the service details
   service_status="$(aws ecs describe-services --cluster="${ECS_CLUSTER}" --services="${ECS_SERVICE}")"
-  # exctract the details for the new deployment (status PRIMARY)
+  # extract the details for the new deployment (status PRIMARY)
   new_deployment="$(echo "${service_status}" | jq -r '.services[0].deployments[] | select(.status == "PRIMARY")')"
 
   # check whether the new deployment is complete


### PR DESCRIPTION
Not all ECS services have secrets, so I added a parameter that will skip checking the task definition for secrets when `false` is supplied.