### PR TITLE
ci: add launch-type input parameter

### DIFF
--- a/deploy-ecs/action.yml
+++ b/deploy-ecs/action.yml
@@ -24,6 +24,10 @@ inputs:
     description: Whether the service needs secrets (expects "true" or "false")
     required: false
     default: 'true'
+  launch-type:
+    description: ECS launch type ("FARGATE" or "EC2")
+    required: false
+    default: 'FARGATE'
 runs:
   using: composite
   steps:
@@ -37,3 +41,4 @@ runs:
         ECS_SERVICE: ${{ inputs.ecs-service }}
         DOCKER_TAG: ${{ inputs.docker-tag }}
         REQUIRES_SECRETS: ${{ inputs.requires-secrets }}
+        LAUNCH_TYPE: ${{ inputs.launch-type }}


### PR DESCRIPTION
I added a parameter which specifies whether the task definition pulled is for an EC2 or Fargate task. This is only a rough mapping onto the underlying behavior though, which is why I was hesitant to add this special case. It doesn't actually change the launch type, it only specifies which attributes should be expected in the existing ECS task definition. If we haven't already looked into it, in the future we might consider using the official AWS ECS actions (e.g. https://github.com/aws-actions/amazon-ecs-render-task-definition, https://github.com/aws-actions/amazon-ecs-deploy-task-definition), as they seem to handle most of what these scripts do, with the main difference here being they expect a task definition JSON file as input.