### PR TITLE
Tweaks to Slack notification action

### DIFF
--- a/notify-slack-deploy/action.yml
+++ b/notify-slack-deploy/action.yml
@@ -8,6 +8,9 @@ inputs:
     description: "Whether the deploy succeeded or failed (default: success)"
     required: true
     default: success
+  custom-message:
+    description: "Custom message to use, if not inferred from deploy"
+    required: false
 runs:
   using: composite
   steps:
@@ -16,4 +19,5 @@ runs:
       env:
         SLACK_WEBHOOK: ${{ inputs.webhook-url }}
         JOB_STATUS: ${{ inputs.job-status }}
+        CUSTOM_MESSAGE: ${{ inputs.custom-message }}
         GITHUB_ENVIRONMENT: ${{ toJSON(github) }}

--- a/notify-slack-deploy/notify.py
+++ b/notify-slack-deploy/notify.py
@@ -28,8 +28,12 @@ field = {
     "value": f"{actor} {run_description} <{html_url}/actions/runs/{run_id}|{workflow}> {run_emoji}",
     "short": False,
 }
+fields = [field]
+if os.environ["CUSTOM_MESSAGE"]:
+    fields.append({"value": os.environ["CUSTOM_MESSAGE"]})
+
 body = {
-    "attachments": [{"fallback": fallback, "color": color, "fields": [field]}],
+    "attachments": [{"fallback": fallback, "color": color, "fields": fields}],
 }
 
 request = urllib.request.Request(

--- a/notify-slack-deploy/notify.py
+++ b/notify-slack-deploy/notify.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 import json
 import os
-import requests
+import urllib.request
+from pprint import pprint
 
 job_status = os.environ["JOB_STATUS"]
 github = json.loads(os.environ["GITHUB_ENVIRONMENT"])
@@ -31,4 +32,14 @@ body = {
     "attachments": [{"fallback": fallback, "color": color, "fields": [field]}],
 }
 
-print(requests.post(os.environ["SLACK_WEBHOOK"], json=body))
+request = urllib.request.Request(
+    os.environ["SLACK_WEBHOOK"], 
+    json.dumps(body).encode("utf-8"),
+    { "Content-Type": "application/json" }
+)
+
+with urllib.request.urlopen(request) as response:
+    print("Status:")
+    pprint(response.status)
+    print("Response body:")
+    pprint(response.read())


### PR DESCRIPTION
I ran into two issues using this action with `gtfs_creator` deploys.

1. The first commit here replaces `requests` with Python3 stdlib modules only. The action currently imports `requests`. I'm a little surprised this works, but I guess the Linux VM used by apps includes some common 3rd party libraries? It didn't work in `gtfs_creator`, likely related to how it sets up its python environment via `asdf` and `poetry`. I'm not sure if we should force clients here to use Python3? I know that migration has been going on for... a decade now.
2. The 2nd commit adds an optional `custom-message` input, to append to the deploy notification. `gtfs_creator`, as part of its deploy, bounces the API and Skate apps. In its deploy on Semaphore, it only actually used the Slack notification about *those* apps previously, so it's nice that it has easy access to notifying about its own deploy now. However, I wanted to also mention in the deploy message that those other apps were restarted. 