### PR TITLE
feat: add task definition name input to deploy-ecs

### DIFF
--- a/deploy-ecs/action.yml
+++ b/deploy-ecs/action.yml
@@ -17,6 +17,9 @@ inputs:
   ecs-service:
     description: ECS service to deploy
     required: true
+  ecs-task-definition:
+    description: ECS task definition name, if different from the service name
+    required: false
   docker-tag:
     description: Docker tag to deploy
     required: true
@@ -39,6 +42,7 @@ runs:
         AWS_REGION: ${{ inputs.aws-region }}
         ECS_CLUSTER: ${{ inputs.ecs-cluster }}
         ECS_SERVICE: ${{ inputs.ecs-service }}
+        ECS_TASK_DEF: ${{ inputs.ecs-task-definition || inputs.ecs-service }}
         DOCKER_TAG: ${{ inputs.docker-tag }}
         REQUIRES_SECRETS: ${{ inputs.requires-secrets }}
         LAUNCH_TYPE: ${{ inputs.launch-type }}


### PR DESCRIPTION
This makes the action compatible with apps such as T-Alerts where the name of the task definition family is different from the service name.

* [Successful deploy to T-Alerts dev-green using this branch with the new option](https://github.com/mbta/alerts_concierge/runs/2897790128)
* [Successful deploy to RTR dev-green using this branch _without_ the new option](https://github.com/mbta/rtr/runs/2898140786) (testing the fallback to service name)