### PR TITLE
fix: workaround missing event info, closes #17

### DIFF
--- a/notify-slack-deploy/notify.py
+++ b/notify-slack-deploy/notify.py
@@ -11,7 +11,12 @@ workflow = github["workflow"]
 repository = github["repository"]
 run_id = github["run_id"]
 
-html_url = github["event"]["repository"]["html_url"]
+# In scheduled events, github["event"] is just the cron string
+if isinstance(github["event"], dict) and "repository" in github["event"]:
+    html_url = github["event"]["repository"]["html_url"]
+else:
+    html_url = f"https://www.github.com/{repository}"
+
 run_description = {"success": "ran", "cancelled": "cancelled", "failure": "failed"}[
     job_status
 ]

--- a/notify-slack-deploy/notify.py
+++ b/notify-slack-deploy/notify.py
@@ -10,12 +10,7 @@ actor = github["actor"]
 workflow = github["workflow"]
 repository = github["repository"]
 run_id = github["run_id"]
-
-# In scheduled events, github["event"] is just the cron string
-if isinstance(github["event"], dict) and "repository" in github["event"]:
-    html_url = github["event"]["repository"]["html_url"]
-else:
-    html_url = f"https://www.github.com/{repository}"
+html_url = f"https://www.github.com/{repository}"
 
 run_description = {"success": "ran", "cancelled": "cancelled", "failure": "failed"}[
     job_status

--- a/notify-slack-deploy/notify.py
+++ b/notify-slack-deploy/notify.py
@@ -10,7 +10,7 @@ actor = github["actor"]
 workflow = github["workflow"]
 repository = github["repository"]
 run_id = github["run_id"]
-application = github["event"]["repository"]["name"]
+
 html_url = github["event"]["repository"]["html_url"]
 run_description = {"success": "ran", "cancelled": "cancelled", "failure": "failed"}[
     job_status


### PR DESCRIPTION
According to [the docs](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events), scheduled events have no event payload. Which seems... very silly to say the least. The [screenshot in this post](https://github.community/t/how-do-i-get-gh-username-based-on-actions-events/17882/3) confirms that the event object for a scheduled workflow has no useful info.

This caused Dotcom to have a problem with the notify-slack-deploy action on its weekly scheduled Deploy to Prod workflow, and this update attempts to ameliorate that.