### PR TITLE
feat: support additional tags for images

### DIFF
--- a/build-push-ecr/action.yml
+++ b/build-push-ecr/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: Additional arguments to pass to call to docker
     required: false
     default: ''
+  docker-additional-tags:
+    description: Additional tags for the image, separated by spaces
+    required: false
+    default: ''
 outputs:
   docker-tag:
     description: Docker Tag
@@ -48,3 +52,10 @@ runs:
       shell: bash
     - run: docker push ${{ steps.docker.outputs.tag }}
       shell: bash
+    - run: >
+        for tag in ${{ inputs.docker-additional-tags }}; do
+          docker tag ${{ steps.docker.outputs.tag }} ${{ inputs.docker-repo }}:$tag
+          docker push ${{ inputs.docker-repo }}:$tag
+        done
+      shell: bash
+      if: ${{ inputs.docker-additional-tags != '' }}


### PR DESCRIPTION
Allow the option to pass one or more additional tags to be associated with container images. The tags will be created and pushed to ECR after the original image is uploaded. The initial use case for this feature is to tag Keycloak images with the version strings used by Integsoft, which will make it easier to see which version is deployed to a particular environment, and streamline rollback deploys if/when necessary.

This has been tested using the [`idw-docker-build` branch](https://github.com/mbta/keycloak-deploy/compare/idw-docker-build) of the keycloak-deploy repo; a successful build can be seen in my fork of the repo [here](https://github.com/ianwestcott/keycloak-deploy/runs/5670477177) (for the time being). I also [tested without passing extra tags](https://github.com/ianwestcott/keycloak-deploy/runs/5693934537) to ensure that the action continues to behave as expected for existing workflows. 