### PR TITLE
feat: Add reusable deploy workflow

### DIFF
--- a/workflows/README.md
+++ b/workflows/README.md
@@ -1,0 +1,33 @@
+# Reusable workflows
+
+This folder collects our [reusable workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows).
+
+## deploy-ecs.yml
+
+Example usage, in **my_app/.github/workflows/deploy-ecs.yml**:
+
+```yml
+name: Deploy to ECS
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        type: environment
+        required: true
+        default: dev
+  push:
+    branches: master
+
+jobs:
+  call-workflow:
+    uses: mbta/actions/workflows/deploy-ecs@main
+    with:
+      app-name: my-app
+      environment: ${{ github.event.inputs.environment || 'dev }}
+    secrets:
+      aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      docker-repo: ${{ secrets.DOCKER_REPO }}
+      slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
+```

--- a/workflows/deploy-ecs.yml
+++ b/workflows/deploy-ecs.yml
@@ -1,0 +1,47 @@
+on:
+  workflow_call:
+    inputs:
+      app-name:
+        type: string
+        required: true
+        description: The name of the app, as used for the ECS cluster
+      environment:
+        type: string
+        required: true
+        description: E.g. 'prod' or 'dev', to concatenate with app for ECS service
+    secrets:
+      aws-access-key-id:
+        required: true
+      aws-secret-access-key:
+        required: true
+      docker-repo:
+        required: true
+      slack-webhook:
+        required: true
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    concurrency: ${{ inputs.environment }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: mbta/actions/build-push-ecr@v1
+        id: build-push
+        with:
+          aws-access-key-id: ${{ secrets.aws-access-key-id }}
+          aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
+          docker-repo: ${{ secrets.docker-repo }}
+      - uses: mbta/actions/deploy-ecs@v1
+        with:
+          aws-access-key-id: ${{ secrets.aws-access-key-id }}
+          aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
+          ecs-cluster: ${{ inputs.app-name }}
+          ecs-service: ${{ inputs.app-name }}-${{ inputs.environment }}
+          docker-tag: ${{ steps.build-push.outputs.docker-tag }}
+      - uses: mbta/actions/notify-slack-deploy@v1
+        if: ${{ !cancelled() }}
+        with:
+          webhook-url: ${{ secrets.slack-webhook }}
+          job-status: ${{ job.status }}


### PR DESCRIPTION
Allows another app to reuse it, e.g.:

**my_app/.github/workflows/deploy.yml**
```   
name: Deploy to ECS

on:
  workflow_dispatch:
    inputs:
      environment:
        type: environment
        required: true
        default: dev
  push:
    branches: master

jobs:
  call-workflow:
    uses: mbta/actions/workflows/deploy@main
    with:
      app-name: my-app
      environment: ${{ github.event.inputs.environment }}
    secrets:
      aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
      aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
      docker-repo: ${{ secrets.DOCKER_REPO }}
      slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
```