### PR TITLE
feat(dialyzer): Ability to disable restore cache keys & increment cache key

### DIFF
--- a/dialyzer/action.yml
+++ b/dialyzer/action.yml
@@ -7,6 +7,12 @@ inputs:
   working-directory:
     description: Directory to change to before running Dialyzer
     default: "."
+  use-fallback-cache-keys:
+    description: Whether or not to use the fallback cache keys, which look for inexact matches.
+    default: "true"
+  cache-key-version:
+    description: a string to change the cache key if the old cached value is stale
+    default: ""
 runs:
   using: "node12"
   main: "dist/main/index.js"

--- a/dialyzer/dist/main/index.js
+++ b/dialyzer/dist/main/index.js
@@ -59753,20 +59753,18 @@ function run() {
         const mixLockHash = yield hashFiles(["mix.lock", "apps/*/mix.lock"]);
         const dialyzerPaths = [" _build/*/*.plt*"];
         const cacheKeyVersion = _actions_core__WEBPACK_IMPORTED_MODULE_1__.getInput("cache-key-version");
-        let cacheKey = `${architecture}-dialyzer-${otp_release}-${erts_version}-${elixir_version}-${mixLockHash}`;
-        if (cacheKeyVersion !== "") {
-            cacheKey = `${cacheKeyVersion}-${cacheKey}`;
-        }
+        const cacheKeyVersionPrefix = cacheKeyVersion === "" ? "" : `${cacheKeyVersion}-`;
+        const cacheKey = `${cacheKeyVersionPrefix}${architecture}-dialyzer-${otp_release}-${erts_version}-${elixir_version}-${mixLockHash}`;
         const shouldUseFallbackCacheKeys = _actions_core__WEBPACK_IMPORTED_MODULE_1__.getInput("use-fallback-cache-keys") === "true";
         console.log("Using fallback cache keys?", shouldUseFallbackCacheKeys);
         const restoreKeys = shouldUseFallbackCacheKeys
             ? [
-                `${architecture}-dialyzer-${otp_release}-${erts_version}-${elixir_version}-`,
-                `${architecture}-dialyzer-${otp_release}-${erts_version}-`,
+                `${cacheKeyVersionPrefix}${architecture}-dialyzer-${otp_release}-${erts_version}-${elixir_version}-`,
+                `${cacheKeyVersionPrefix}${architecture}-dialyzer-${otp_release}-${erts_version}-`,
                 // previous version of the Dialyzer cache
-                `${architecture}-dialyzer-${otp_release}-${elixir_version}-`,
-                `${architecture}-dialyzer-${otp_release}-`,
-                `${architecture}-dialyzer-`,
+                `${cacheKeyVersionPrefix}${architecture}-dialyzer-${otp_release}-${elixir_version}-`,
+                `${cacheKeyVersionPrefix}${architecture}-dialyzer-${otp_release}-`,
+                `${cacheKeyVersionPrefix}${architecture}-dialyzer-`,
             ]
             : [];
         let cacheId = null;

--- a/dialyzer/dist/main/index.js
+++ b/dialyzer/dist/main/index.js
@@ -59755,7 +59755,7 @@ function run() {
         const cacheKeyVersion = _actions_core__WEBPACK_IMPORTED_MODULE_1__.getInput("cache-key-version");
         let cacheKey = `${architecture}-dialyzer-${otp_release}-${erts_version}-${elixir_version}-${mixLockHash}`;
         if (cacheKeyVersion !== "") {
-            cacheKey = `${cacheKey}-${cacheKeyVersion}`;
+            cacheKey = `${cacheKeyVersion}-${cacheKey}`;
         }
         const shouldUseFallbackCacheKeys = _actions_core__WEBPACK_IMPORTED_MODULE_1__.getInput("use-fallback-cache-keys") === "true";
         console.log("Using fallback cache keys?", shouldUseFallbackCacheKeys);

--- a/dialyzer/src/main.ts
+++ b/dialyzer/src/main.ts
@@ -93,22 +93,21 @@ async function run(): Promise<void> {
   const mixLockHash = await hashFiles(["mix.lock", "apps/*/mix.lock"]);
   const dialyzerPaths = [" _build/*/*.plt*"];
   const cacheKeyVersion = core.getInput("cache-key-version");
-  let cacheKey = `${architecture}-dialyzer-${otp_release}-${erts_version}-${elixir_version}-${mixLockHash}`;
-  if (cacheKeyVersion !== "") {
-    cacheKey = `${cacheKeyVersion}-${cacheKey}`;
-  }
+  const cacheKeyVersionPrefix =
+    cacheKeyVersion === "" ? "" : `${cacheKeyVersion}-`;
+  const cacheKey = `${cacheKeyVersionPrefix}${architecture}-dialyzer-${otp_release}-${erts_version}-${elixir_version}-${mixLockHash}`;
 
   const shouldUseFallbackCacheKeys =
     core.getInput("use-fallback-cache-keys") === "true";
   console.log("Using fallback cache keys?", shouldUseFallbackCacheKeys);
   const restoreKeys = shouldUseFallbackCacheKeys
     ? [
-        `${architecture}-dialyzer-${otp_release}-${erts_version}-${elixir_version}-`,
-        `${architecture}-dialyzer-${otp_release}-${erts_version}-`,
+        `${cacheKeyVersionPrefix}${architecture}-dialyzer-${otp_release}-${erts_version}-${elixir_version}-`,
+        `${cacheKeyVersionPrefix}${architecture}-dialyzer-${otp_release}-${erts_version}-`,
         // previous version of the Dialyzer cache
-        `${architecture}-dialyzer-${otp_release}-${elixir_version}-`,
-        `${architecture}-dialyzer-${otp_release}-`,
-        `${architecture}-dialyzer-`,
+        `${cacheKeyVersionPrefix}${architecture}-dialyzer-${otp_release}-${elixir_version}-`,
+        `${cacheKeyVersionPrefix}${architecture}-dialyzer-${otp_release}-`,
+        `${cacheKeyVersionPrefix}${architecture}-dialyzer-`,
       ]
     : [];
 

--- a/dialyzer/src/main.ts
+++ b/dialyzer/src/main.ts
@@ -95,7 +95,7 @@ async function run(): Promise<void> {
   const cacheKeyVersion = core.getInput("cache-key-version");
   let cacheKey = `${architecture}-dialyzer-${otp_release}-${erts_version}-${elixir_version}-${mixLockHash}`;
   if (cacheKeyVersion !== "") {
-    cacheKey = `${cacheKey}-${cacheKeyVersion}`;
+    cacheKey = `${cacheKeyVersion}-${cacheKey}`;
   }
 
   const shouldUseFallbackCacheKeys =


### PR DESCRIPTION
Since upgrading Oban, Draft has been seeing regular failures of the dialyzer step in CI. Rerunning those failing actions works successfully thanks to Paul's [PR](https://github.com/mbta/actions/pull/23) to disable the cache on job reruns. 

However, those reruns fail to save the newly produced PLT due to a ` ReserveCacheError: Unable to reserve cache with key` (seen on [this](https://github.com/mbta/draft/runs/6377938361?check_suite_focus=true) run). It seems that the cache save will always fail if there is already a value saved for that same key (issue thread on this [here](https://github.com/actions/toolkit/issues/658#issuecomment-1019398065)).

Looking into why the [original dialyzer run](https://github.com/mbta/draft/runs/6290575820?check_suite_focus=true) from the oban upgrade is failing, it seems to be due to the following:
* There was no exact cache key hit using the hashed mix.lock file, because this is the first run with the new mix.lock
* There was an inexact cache key hit using one of the restore cache keys
* Since it wasn't an exact match, `mix dialyzer --plt` is run. However, that doesn't build the PLT from scratch - it starts with the PLT that was restored from the inexact cache key match. That seems to be an issue for this Oban upgrade - something doesn't get rebuild that should have, and the dialyzer check fails. However, that bad PLT is saved for the new cache key and is used on all subsequent runs, resulting in failure every time.


This PR adds 2 new pieces of input to the dialyzer action to help Draft get out of this stuck state
* use-fallback-cache-keys to support disabling the inexact cache key matching behavior
* cache-key-version so we can increment the cache key & rebuild a new PLT for the latest `mix.lock`.


Testing
Failure on Draft branch before this change: https://github.com/mbta/draft/runs/6388680884?check_suite_focus=true
Success after this change: https://github.com/mbta/draft/runs/6389132615?check_suite_focus=true