### PR TITLE
feat(build-push-ecr): check if image exists before building

### DIFF
--- a/build-push-ecr/action.yml
+++ b/build-push-ecr/action.yml
@@ -49,18 +49,28 @@ runs:
       id: docker
       shell: bash
     - run: >
-        docker build
-        ${{ inputs.docker-additional-args }}
-        --pull -t ${{ steps.docker.outputs.tag }} ${{ inputs.dockerfile-path }}
-      shell: bash
-    - run: >
         aws ecr get-login-password --region ${{ inputs.aws-region }}
         | docker login --username AWS --password-stdin ${{ inputs.docker-repo }}
       env:
         AWS_ACCESS_KEY_ID: ${{ inputs.aws-access-key-id }}
         AWS_SECRET_ACCESS_KEY: ${{ inputs.aws-secret-access-key }}
       shell: bash
-    - run: docker push ${{ steps.docker.outputs.tag }}
+      # check if image with this tag has already been built and uploaded
+    - run: >
+        repo_name_with_tag=$(echo "${{ steps.docker.outputs.tag }}" | cut -d/ -f2)
+        repo_name=$(echo $repo_name_with_tag | cut -d: -f1)
+        image_name=$(echo $repo_name_with_tag | cut -d: -f2)
+        echo "::set-output name=exists::$(aws ecr list-images --repository-name $repo_name | grep $image_name)"
+      shell: bash
+      id: image-check
+    - if: ${{ !steps.image-check.output.exists }}
+      run: >
+        docker build
+        ${{ inputs.docker-additional-args }}
+        --pull -t ${{ steps.docker.outputs.tag }} ${{ inputs.dockerfile-path }}
+      shell: bash
+    - if: ${{ !steps.image-check.output.exists }}
+      run: docker push ${{ steps.docker.outputs.tag }}
       shell: bash
     - run: >
         for tag in ${{ inputs.docker-additional-tags }}; do

--- a/build-push-ecr/action.yml
+++ b/build-push-ecr/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: AWS region to use
     required: true
     default: us-east-1
+  custom-tag:
+    description: Custom tag for image in ECR repo
+    required: false
+    default: ''
   docker-repo:
     description: ECR Docker repo to push to
     required: true
@@ -35,7 +39,13 @@ runs:
   steps:
     - run: test -n "${{ inputs.aws-access-key-id }}" -a -n "${{ inputs.aws-secret-access-key }}"
       shell: bash
-    - run: echo "::set-output name=tag::${{ inputs.docker-repo }}:git-$(git rev-parse --short HEAD)"
+    - run: >
+        if [[ "${{ inputs.custom-tag }}" == '' ]]
+        then
+          echo "::set-output name=tag::${{ inputs.docker-repo }}:git-$(git rev-parse --short HEAD)"
+        else
+          echo "::set-output name=tag::${{ inputs.docker-repo }}:${{ inputs.custom-tag }}"
+        fi
       id: docker
       shell: bash
     - run: >

--- a/build-push-ecr/action.yml
+++ b/build-push-ecr/action.yml
@@ -57,10 +57,10 @@ runs:
       shell: bash
       # check if image with this tag has already been built and uploaded
     - run: >
-        repo_name_with_tag=$(echo "${{ steps.docker.outputs.tag }}" | cut -d/ -f2)
-        repo_name=$(echo $repo_name_with_tag | cut -d: -f1)
-        image_name=$(echo $repo_name_with_tag | cut -d: -f2)
-        echo "::set-output name=exists::$(aws ecr list-images --repository-name $repo_name | grep $image_name)"
+        repo=$(echo "${{ steps.docker.outputs.tag }}" | cut -d/ -f2 | cut -d: -f1)
+        image=$(echo "${{ steps.docker.outputs.tag }}" | cut -d/ -f2 | cut -d: -f2)
+        image_in_repo=$(aws ecr list-images --repository-name $repo | grep $image)"
+        echo "::set-output name=exists::$image_in_repo"
       shell: bash
       id: image-check
     - if: ${{ !steps.image-check.output.exists }}


### PR DESCRIPTION
Our `build-push-ecr` action will build, tag, and push our application's docker image, even if it had been built and pushed prior. For example, for Dotcom every commit is deployed to dev before it's deployed to prod, thus the same image could be used for each. Some commits might even be deployed to another staging environment beforehand.

Each build is rather lengthy, and the repeated builds are not helpful, so I wanted to see if I could update this action to be smart enough to skip the build step if the relevant image exists. I welcome any opinions on the idea or feedback on the implementation!

While here, I thought it might be helpful to add support for a custom tag if we didn't want the default `git-1234567` format -- this is a completely separate notion though, and I can remove it if it isn't helpful.