### PR TITLE
fix: stop using `set-output`

### DIFF
--- a/build-push-ecr/action.yml
+++ b/build-push-ecr/action.yml
@@ -35,7 +35,7 @@ runs:
   steps:
     - run: test -n "${{ inputs.aws-access-key-id }}" -a -n "${{ inputs.aws-secret-access-key }}"
       shell: bash
-    - run: echo "::set-output name=tag::${{ inputs.docker-repo }}:git-$(git rev-parse --short HEAD)"
+    - run: echo "tag=${{ inputs.docker-repo }}:git-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       id: docker
       shell: bash
     - run: >

--- a/commit-metadata/action.yml
+++ b/commit-metadata/action.yml
@@ -13,10 +13,10 @@ runs:
     - shell: bash
       id: git
       run: |
-        echo ::set-output name=sha-short::$(git rev-parse --short ${{ github.sha }})
-        echo ::set-output name=commit-message::$(
+        echo "sha-short=$(git rev-parse --short ${{ github.sha }})" >> $GITHUB_OUTPUT
+        echo "commit-message=$(
           git log --format=%B -n 1 ${{ github.sha }} | head -n 1
-        )
+        )" >> $GITHUB_OUTPUT
     - shell: bash
       run: |
         cat <<EOF

--- a/eb-ecr-dockerrun/action.yml
+++ b/eb-ecr-dockerrun/action.yml
@@ -17,10 +17,10 @@ runs:
     - shell: bash
       id: build
       run: |
-        echo ::set-output name=package::$(
+        echo "package=$(
             mktemp -d $RUNNER_TEMP/package-XXXXXX
-          )/${{ github.sha }}.zip
-        echo ::set-output name=dir::$(mktemp -d $RUNNER_TEMP/deploy-XXXXXX)
+          )/${{ github.sha }}.zip" >> $GITHUB_OUTPUT
+        echo "dir=$(mktemp -d $RUNNER_TEMP/deploy-XXXXXX)" >> $GITHUB_OUTPUT
     - shell: bash
       run: |
         test -d rel/.ebextensions && cp -r rel/.ebextensions ${{ steps.build.outputs.dir }}


### PR DESCRIPTION
Blog post: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/