### PR TITLE
feat: add Dependabot support for Github Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,6 @@ updates:
     schedule:
       interval: "weekly"
     reviewers:
-      - "mbta/ctd-infrastructure"
+      - "mbta/tid-tech-leads"
     commit-message:
       prefix: "[github-actions]"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot#example-dependabotyml-file-for-github-actions
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#about-the-dependabotyml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "mbta/ctd-infrastructure"
+    commit-message:
+      prefix: "[github-actions]"


### PR DESCRIPTION
I was going to add a PR to update a reference to a particular outdated action used in a particular workflow, but I figure I can also enable this to have Dependabot create the PRs for me. Any thoughts? :) 