### PR TITLE
Fix: Allow multiple docker additional arguments

### DIFF
--- a/build-push-ecr/action.yml
+++ b/build-push-ecr/action.yml
@@ -31,7 +31,7 @@ runs:
   using: composite
   steps:
     - name: Setup AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: ${{ inputs.aws-region }}
@@ -50,7 +50,8 @@ runs:
     - run: docker push ${{ steps.docker.outputs.tag }}
       shell: bash
     - run: >
-        for tag in ${{ inputs.docker-additional-tags }}; do
+        docker_additional_tags=(${{ inputs.docker-additional-tags }})
+        for tag in ${docker_additional_tags[@]}; do
           docker tag ${{ steps.docker.outputs.tag }} ${{ inputs.docker-repo }}:$tag
           docker push ${{ inputs.docker-repo }}:$tag
         done

--- a/build-push-ecr/action.yml
+++ b/build-push-ecr/action.yml
@@ -50,7 +50,7 @@ runs:
     - run: docker push ${{ steps.docker.outputs.tag }}
       shell: bash
     - run: >
-        docker_additional_tags=(${{ inputs.docker-additional-tags }})
+        docker_additional_tags=(${{ inputs.docker-additional-tags }});
         for tag in ${docker_additional_tags[@]}; do
           docker tag ${{ steps.docker.outputs.tag }} ${{ inputs.docker-repo }}:$tag
           docker push ${{ inputs.docker-repo }}:$tag


### PR DESCRIPTION
### Summary
While pairing with @nihonjinrxs on the MyCharlie prod deploy, we noticed [failures](https://github.com/mbta/my_charlie/actions/runs/6724958432) related to the number of arguments passed into the workflow run. 

![Screenshot 2023-11-02 at 2 23 55 PM](https://github.com/mbta/actions/assets/49254078/38fcdb9c-49f4-41ed-9a1b-678482c207eb)

After some investigation, we came upon [this documentation](https://www.freecodecamp.org/news/bash-array-how-to-declare-an-array-of-strings-in-a-bash-script/), revealing that we were missing an `@` symbol allowing bash to loop over every additional tag, not just the first additional tag. 

This has been tested in several spots:
- [MyCharlie Staging](https://github.com/mbta/my_charlie/actions/runs/6723318774) (one additional tag)
- [MyCharlie Prod](https://github.com/mbta/my_charlie/actions/runs/6725813256) (two additional tags)
- [Keycloak Dev](https://github.com/mbta/keycloak-deploy/actions/runs/6736536658) (one additional tag)

### Next Steps:
- [x] Merge this PR
- [x] Repoint the V2 tag to commit hash `323533c`
- [ ] Coordinate with @nihonjinrxs to update the MyCharlie workflow back to the `V2` tag