### PR TITLE
feat: move build-push-ecr to Docker actions

### DIFF
--- a/build-push-ecr/action.yml
+++ b/build-push-ecr/action.yml
@@ -38,7 +38,7 @@ inputs:
 outputs:
   docker-tag:
     description: Docker Tag
-    value: ${{ steps.meta.outputs.version }}
+    value: ${{ inputs.docker-repo }}:${{ steps.meta.outputs.version }}
 runs:
   using: composite
   steps:

--- a/build-push-ecr/action.yml
+++ b/build-push-ecr/action.yml
@@ -6,27 +6,39 @@ inputs:
     required: true
   aws-region:
     description: AWS region to use
-    required: true
+    required: false
     default: us-east-1
   docker-repo:
     description: ECR Docker repo to push to
     required: true
   dockerfile-path:
-    description: Path to the repo's Dockerfile
+    description: Path to the build context, i.e. the folder containing the Dockerfile
     required: false
-    default: '.'
+    default: "."
   docker-additional-args:
-    description: Additional arguments to pass to call to docker
+    description: |
+      Deprecated. Build arguments in command-line form (`--build-arg FOO=bar`), separated by spaces.
+      Replace with docker-build-args when possible.
     required: false
-    default: ''
+    default: ""
   docker-additional-tags:
-    description: Additional tags for the image, separated by spaces
+    description: |
+      Additional tags for the image, separated by spaces.
+
+      Can also be formatted for docker/metadata-action (e.g. type=ref,event=tag) and
+      separated by newlines.
+      The primary tag is `type=sha,priority=1000,prefix=git`.
+      To override the docker-tag output, pass in something with priority above 1000.
     required: false
-    default: ''
+    default: ""
+  docker-build-args:
+    description: Build args for the Docker container (`FOO=bar`), separated by newlines.
+    required: false
+    default: ""
 outputs:
   docker-tag:
     description: Docker Tag
-    value: ${{ steps.docker.outputs.tag }}
+    value: ${{ steps.meta.outputs.version }}
 runs:
   using: composite
   steps:
@@ -35,25 +47,69 @@ runs:
       with:
         role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: ${{ inputs.aws-region }}
-    - run: echo "tag=${{ inputs.docker-repo }}:git-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-      id: docker
+    - name: Calculate tags
+      id: additional-tags
       shell: bash
-    - run: >
-        docker build
-        ${{ inputs.docker-additional-args }}
-        --pull -t ${{ steps.docker.outputs.tag }} ${{ inputs.dockerfile-path }}
-      shell: bash
-    - run: >
-        aws ecr get-login-password --region ${{ inputs.aws-region }}
-        | docker login --username AWS --password-stdin ${{ inputs.docker-repo }}
-      shell: bash
-    - run: docker push ${{ steps.docker.outputs.tag }}
-      shell: bash
-    - run: >
-        docker_additional_tags=(${{ inputs.docker-additional-tags }});
-        for tag in ${docker_additional_tags[@]}; do
-          docker tag ${{ steps.docker.outputs.tag }} ${{ inputs.docker-repo }}:$tag
-          docker push ${{ inputs.docker-repo }}:$tag
-        done
-      shell: bash
+      run: |
+        {
+          echo 'tags<<EOF'
+          if ${{ contains(inputs.docker-additional-tags, '=') }}; then
+            # already in the right format for docker/metadata-action
+            echo "${{ inputs.docker-additional-tags }}"
+          else
+            # pass tags in as raw
+            docker_additional_tags=(${{ inputs.docker-additional-tags }})
+            for tag in ${docker_additional_tags[@]}; do
+              echo "type=raw,priority=900,value=${tag}"
+            done
+          fi
+          echo 'EOF'
+        } | tee -a "$GITHUB_OUTPUT"
       if: ${{ inputs.docker-additional-tags != '' }}
+    - name: Calculate build args
+      id: build-args
+      shell: bash
+      run: |
+        {
+          echo 'build-args<<EOF'
+          if ${{ inputs.docker-additional-args != '' }}; then
+            docker_additional_args=(${{ inputs.docker-additional-args }})
+            EXPECTED_FLAG="the --build-arg flag"
+            EXPECTED_ARG="an argument like FOO=bar"
+            arg_expected="$EXPECTED_FLAG"
+            for arg in ${docker_additional_args[@]}; do
+              if [[ "$arg_expected" = "$EXPECTED_FLAG" && "$arg" = "--build-arg" ]]; then
+                arg_expected="$EXPECTED_ARG"
+              elif [[ "$arg_expected" = "$EXPECTED_ARG" && "$arg" =~ "=" ]]; then
+                echo "$arg"
+                arg_expected="$EXPECTED_FLAG"
+              else
+                echo "Expected $arg_expected, got '$arg'" >&2
+                exit 1
+              fi
+            done
+          fi
+          echo "${{ inputs.docker-build-args }}"
+          echo 'EOF'
+        } | tee -a "$GITHUB_OUTPUT"
+      if: ${{ inputs.docker-additional-args != '' || inputs.docker-build-args != '' }}
+    - uses: docker/metadata-action@v5
+      id: meta
+      with:
+        images: ${{ inputs.docker-repo }}
+        tags: |
+          type=sha,priority=1000,prefix=git-
+          ${{ steps.additional-tags.outputs.tags }}
+    - uses: docker/setup-buildx-action@v3
+    - uses: docker/build-push-action@v5
+      with:
+        load: true
+        context: ${{ inputs.dockerfile-path }}
+        build-args: ${{ steps.build-args.outputs.build-args }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+    - uses: aws-actions/amazon-ecr-login@v2
+    - name: docker push
+      run: docker push --all-tags ${{ inputs.docker-repo }}

--- a/build-push-ecr/action.yml
+++ b/build-push-ecr/action.yml
@@ -103,6 +103,7 @@ runs:
     - uses: docker/setup-buildx-action@v3
     - uses: docker/build-push-action@v5
       with:
+        pull: true
         load: true
         context: ${{ inputs.dockerfile-path }}
         build-args: ${{ steps.build-args.outputs.build-args }}

--- a/build-push-ecr/action.yml
+++ b/build-push-ecr/action.yml
@@ -113,3 +113,4 @@ runs:
     - uses: aws-actions/amazon-ecr-login@v2
     - name: docker push
       run: docker push --all-tags ${{ inputs.docker-repo }}
+      shell: bash


### PR DESCRIPTION
[docker/build-push-action](https://github.com/marketplace/actions/build-and-push-docker-images) has a lot more functionality than is available in a bare `docker build` command, like caching with GitHub Actions and cleaner support for multiple tags. As such, some projects don't use `mbta/actions/build-push-ecr`, which means our Docker build process is fragmented. Moving this action to `docker/build-push-action` should let more complexity move to the shared actions.

This was also the intent of #28, which stalled out in the review process. It was a great foundation to build on - thanks a ton @thecristen! - but I've made a few additional changes:
- As it stands, the `docker-additional-args` input is just arbitrary command line flags passed to `docker build`, and `docker/build-push-action` has no mechanism to provide arbitrary command line flags, since it wants to encapsulate all of the available complexity in its own inputs instead. Conveniently, however, GitHub is willing to [list](https://github.com/mbta/actions/network/dependents?owner=mbta&package_id=UGFja2FnZS0yOTQ3MDkyODI0) all the @mbta repositories that use this action, and only two of them pass `docker-additional-args` ([Skate](https://github.com/mbta/skate/blob/37deccf9c2ef63603f2cc094c7775a8ef970f48d/.github/workflows/deploy-base.yml#L57) and [OTP-deploy](https://github.com/mbta/otp-deploy/blob/d799eb5fa0cf7aa53edca6b8d5b91a20569774d7/.github/workflows/deploy.yml#L72-L75)), and both of those are only using `--build-arg`, so with a bit of shell scripting it's possible to maintain backwards compatibility. It's not really pleasant, though, so I'd be inclined to encourage those projects to migrate to a more direct mechanism as soon as this gets released, so it can be removed promptly before anything else starts to use it.
- `docker/metadata-action`, which I hadn't known about until reading #28, has a lot of extremely cool functionality for applying tags conditionally. Glides, which applies an extra tag to prod deploys and uses that tag in the ECS task definition, has [a ton of mess](https://github.com/mbta/glides/blob/86190a8037e6eea2b5d7abb06508bbf2888d04e7/.github/workflows/deploy.yml#L42-L58) that can be mostly replaced with the `docker/metadata-action` tag logic. As such, it seems like it's worth trying to allow inputs to directly pass `docker/metadata-action` tag rules. The existing behavior of allowing a space-separated list in `docker-additional-tags` is more widely used than the existing `docker-additional-args` behavior, though, and it would be both more annoying and less valuable to migrate that department-wide, so I think it probably makes sense to support both behaviors indefinitely.
- Tags are stuffed into the task output directly, via [GitHub Actions's multiline strings in output files syntax](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings), so there is no temporary file generated.
- The `dockerfile-path` argument does not actually represent a path to a Dockerfile, but rather the path to the folder containing the Dockerfile. Since the current process is not `docker build -f ${{ inputs.dockerfile-path }}` but `docker build ${{ inputs.dockerfile-path }}`, the `dockerfile-path` input is properly provided to `docker/build-push-action` not as `file:` but as `context:`. The name is misleading, but that can't be changed backwards-compatibly.
- Logs into the Docker registry with `aws-actions/amazon-ecr-login` instead of passing long-lived credentials to Docker directly.
- Loads the container into the local Docker instance with `load: true`, and then pushes separately with `docker push --all-tags`. This is actually a really elegant solution to the fact that `docker/build-push-action` is broken in such a way that `push: true` and `load: true` are mutually exclusive, and I wish I'd found `--all-tags` in the `docker push` documentation earlier (although it may not have been there earlier).

Open questions:
1. At what point should a composite action be replaced with a reusable workflow? I think this may be across that line - it seems like it could be helpful to have the nicer UI for nested workflow calls, given how much is going on in this process now - but I don't know where the line really is. I'd be at peace moving this to `mbta/workflows`, but everything would have to migrate manually. (That'd save us some backwards compatibility issues, though.)
2. For some reason, `aws-actions/amazon-ecr-login` appears to technically leak the AWS account ID (via the ECR registry URL) in the GitHub Actions output. (Ask me on Slack for the link that shows this.) Does that matter?
3. How much testing is it worth doing before releasing this? I think most repos pin to `mbta/actions@v2` rather than a specific minor version, but if this does wind up breaking something, it's not all that difficult to pin to `@v2.2.1` or whatever until we can get it fixed.
4. **resolved: not if we `pull: true`.** Do we need the ability to disable the cache? I think we're mostly pretty good about starting with immutable images in our Dockerfiles, but if anything is doing `FROM alpine:latest` or what have you, it may pull from the cache before it pulls from the Docker Hub, in which case it'd always be at the old version of `alpine:latest` now that we're caching, causing this to technically be a breaking change. Several things have to go very wrong before that becomes a problem, though.