### PR TITLE
fix: mask AWS account ID in GitHub Actions output

### DIFF
--- a/build-push-ecr/action.yml
+++ b/build-push-ecr/action.yml
@@ -35,6 +35,7 @@ runs:
       with:
         role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: ${{ inputs.aws-region }}
+        mask-aws-account-id: true
     - run: echo "tag=${{ inputs.docker-repo }}:git-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       id: docker
       shell: bash

--- a/deploy-ecs/action.yml
+++ b/deploy-ecs/action.yml
@@ -36,6 +36,7 @@ runs:
       with:
         role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: ${{ inputs.aws-region }}
+        mask-aws-account-id: true
     - run: ${{ github.action_path }}/deploy.sh
       shell: bash
       env:

--- a/deploy-lambda/action.yaml
+++ b/deploy-lambda/action.yaml
@@ -30,6 +30,7 @@ runs:
       with:
         role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: ${{ inputs.aws-region }}
+        mask-aws-account-id: true
     - name: Package the Lambda function
       shell: bash
       run: |

--- a/deploy-scheduled-ecs/action.yaml
+++ b/deploy-scheduled-ecs/action.yaml
@@ -30,6 +30,7 @@ runs:
       with:
         role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: ${{ inputs.aws-region }}
+        mask-aws-account-id: true
     - name: Deploy to ECS
       id: deploy-ecs
       run: ${{ github.action_path }}/deploy.sh

--- a/run-ecs-fargate-task/action.yml
+++ b/run-ecs-fargate-task/action.yml
@@ -31,6 +31,7 @@ runs:
       with:
         role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: ${{ inputs.aws-region }}
+        mask-aws-account-id: true
     - run: ${{ github.action_path }}/action.sh
       shell: bash
       env:


### PR DESCRIPTION
Relevant documentation:

- [`aws-actions/configure-aws-credentials`: Mask account ID](https://github.com/aws-actions/configure-aws-credentials#mask-account-id)
- [Workflow commands for GitHub Actions: Masking a value in a log](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#masking-a-value-in-a-log)

From what I can tell via [this thread](https://github.com/orgs/community/discussions/26636#discussioncomment-3252661), once the account ID is marked as masked, it will be redacted everywhere.

One caveat to note, via the [GitHub Actions documentation](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#masking-a-value-in-a-log):

> When you mask a value, it is treated as a secret and will be redacted on the runner. For example, after you mask a value, you won't be able to set that value as an output.

This should not be an issue for us, since (AFAICT) we don't need to share the account ID or anything containing it (such as the ECR URI) as an output from any of our actions or workflows.

## TODO

Once merged:

- [ ] Tag `v2.2.2` release
- [ ] Update `v2` tag

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205994012735525