### PR TITLE
Chore: Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# The Tech Leads team will be the default owners for everything in
+# the Actions repo.
+*       @mbta/tid-tech-leads
+


### PR DESCRIPTION
As begun in #37, adding a `CODEOWNERS` file to allow the tid-tech-leads team to round-robin all Actions PRs. A similar PR will be coming shortly in the [Workflows repo](https://github.com/mbta/workflows). 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206311810004640