### PR TITLE
Update referenced configure-aws-credentials version

### DIFF
--- a/deploy-ecs/action.yml
+++ b/deploy-ecs/action.yml
@@ -32,7 +32,7 @@ runs:
   using: composite
   steps:
     - name: Setup AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: ${{ inputs.aws-region }}


### PR DESCRIPTION
Looking through the changelog, there weren't any changes around the inputs we're using here.

Updating this to v4 will remove these pesky NodeJS deprecation warnings.
<img width="891" alt="image" src="https://github.com/mbta/actions/assets/2136286/d5696cfb-2322-4d21-9257-bc2151f4386d">
