### PR TITLE
 fix(deploy-ecs/deploy.sh): replace `echo`'s with `printf` 

### DIFF
--- a/deploy-ecs/deploy.sh
+++ b/deploy-ecs/deploy.sh
@@ -17,7 +17,6 @@ set -e -u
 
 function check_deployment_complete() {
   # extract task counts and test whether they match the desired state
-
   local deployment_details
   local rollout_status
   local desired_count
@@ -27,15 +26,19 @@ function check_deployment_complete() {
 
   # get rollout state
   rollout_status="$(echo "${deployment_details}" | jq -r '.rolloutState')"
-  echo "Rollout Status: ${rollout_status}"
 
-  # get and print current task counts
+  # get current task counts
   desired_count="$(echo "${deployment_details}" | jq -r '[.desiredCount, 1] | max')"
   pending_count="$(echo "${deployment_details}" | jq -r '.pendingCount')"
   running_count="$(echo "${deployment_details}" | jq -r '.runningCount')"
-  echo "Desired count: ${desired_count}"
-  echo "Pending count: ${pending_count}"
-  echo "Running count: ${running_count}"
+
+  # print status, and task counts
+  printf \
+    "Status: %+12s, Running: %3d, Pending: %3d, Desired: %3d\n" \
+    "${rollout_state}" \
+    "${running_count}" \
+    "${pending_count}" \
+    "${desired_count}"
 
   # ensure that AWS believes the deployment to be completed
   # and if the number of running tasks equals the number of desired tasks, then we're all set

--- a/deploy-ecs/deploy.sh
+++ b/deploy-ecs/deploy.sh
@@ -23,6 +23,8 @@ function check_deployment_complete() {
   local desired_count
   local pending_count
   local running_count
+  local failed_count
+
   deployment_details="${1}"
 
   id="$(echo "${deployment_details}" | jq -r '.id')"
@@ -34,13 +36,15 @@ function check_deployment_complete() {
   desired_count="$(echo "${deployment_details}" | jq -r '[.desiredCount, 1] | max')"
   pending_count="$(echo "${deployment_details}" | jq -r '.pendingCount')"
   running_count="$(echo "${deployment_details}" | jq -r '.runningCount')"
+  failed_count="$(echo "${deployment_details}" | jq -r '.failedTasks')"
 
   # print current id, status, and task counts
   printf \
-    "id: %s, Status: %+12s, Running: %3d, Pending: %3d, Desired: %3d\n" \
+    "id: %s, Status: %+12s, Running: %3d, Failed: %3d, Pending: %3d, Desired: %3d\n" \
     "${id}" \
     "${rollout_state}" \
     "${running_count}" \
+    "${failed_count}" \
     "${pending_count}" \
     "${desired_count}"
 

--- a/deploy-ecs/deploy.sh
+++ b/deploy-ecs/deploy.sh
@@ -134,7 +134,6 @@ while [ "${deployment_finished}" = "false" ]; do
       exit 1
     fi
     # wait, then loop
-    echo "Waiting for new tasks to start..."
     sleep 5
   fi
 done

--- a/deploy-ecs/deploy.sh
+++ b/deploy-ecs/deploy.sh
@@ -18,11 +18,14 @@ set -e -u
 function check_deployment_complete() {
   # extract task counts and test whether they match the desired state
   local deployment_details
+  local id
   local rollout_status
   local desired_count
   local pending_count
   local running_count
   deployment_details="${1}"
+
+  id="$(echo "${deployment_details}" | jq -r '.id')"
 
   # get rollout state
   rollout_status="$(echo "${deployment_details}" | jq -r '.rolloutState')"
@@ -32,9 +35,10 @@ function check_deployment_complete() {
   pending_count="$(echo "${deployment_details}" | jq -r '.pendingCount')"
   running_count="$(echo "${deployment_details}" | jq -r '.runningCount')"
 
-  # print status, and task counts
+  # print current id, status, and task counts
   printf \
-    "Status: %+12s, Running: %3d, Pending: %3d, Desired: %3d\n" \
+    "id: %s, Status: %+12s, Running: %3d, Pending: %3d, Desired: %3d\n" \
+    "${id}" \
     "${rollout_state}" \
     "${running_count}" \
     "${pending_count}" \


### PR DESCRIPTION
Cleans up the `echo` statements in `check_deployment_complete` to make tracking changes over time a bit easier. Instead of a bunch of multi line print statements, this instead prints everything on a single line with padding handled by `printf` so that the text location stays in the same place over time.

Depends on:
- #48 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207171341311400