### PR TITLE
feat(deploy-ecs/deploy.sh): assert that deployment is `COMPLETED`

### DIFF
--- a/deploy-ecs/deploy.sh
+++ b/deploy-ecs/deploy.sh
@@ -32,7 +32,7 @@ function check_deployment_complete() {
   echo "Pending count: ${pending_count}"
   echo "Running count: ${running_count}"
   # if the number of running tasks equals the number of desired tasks, then we're all set
-  [ "${pending_count}" -eq "0" ] && [ "${running_count}" -eq "${desired_count}" ]
+  [[ "${pending_count}" -eq "0" ]] && [[ "${running_count}" -eq "${desired_count}" ]]
 }
 
 # set default region so we don't have to specify --region everywhere

--- a/deploy-ecs/deploy.sh
+++ b/deploy-ecs/deploy.sh
@@ -19,10 +19,15 @@ function check_deployment_complete() {
   # extract task counts and test whether they match the desired state
 
   local deployment_details
+  local rollout_status
   local desired_count
   local pending_count
   local running_count
   deployment_details="${1}"
+
+  # get rollout state
+  rollout_status="$(echo "${deployment_details}" | jq -r '.rolloutState')"
+  echo "Rollout Status: ${rollout_status}"
 
   # get and print current task counts
   desired_count="$(echo "${deployment_details}" | jq -r '[.desiredCount, 1] | max')"
@@ -31,8 +36,12 @@ function check_deployment_complete() {
   echo "Desired count: ${desired_count}"
   echo "Pending count: ${pending_count}"
   echo "Running count: ${running_count}"
-  # if the number of running tasks equals the number of desired tasks, then we're all set
-  [[ "${pending_count}" -eq "0" ]] && [[ "${running_count}" -eq "${desired_count}" ]]
+
+  # ensure that AWS believes the deployment to be completed
+  # and if the number of running tasks equals the number of desired tasks, then we're all set
+  [[ "${rollout_status}" = "COMPLETED" ]] \
+  && [[ "${pending_count}" -eq "0" ]] \
+  && [[ "${running_count}" -eq "${desired_count}" ]]
 }
 
 # set default region so we don't have to specify --region everywhere


### PR DESCRIPTION
# Summary
On Skate, we've had a few deploys silently fail and FP successful complete. This was because `deploy-ecs/deploy.sh` was unaware that the deployments may be rolled back by the AWS circuit breaker. By checking if the deploy completed, we now know whether the deploy was successful or not, regardless of the circuit breaker's presence.


<details open>
<summary>

## Examples

</summary>

The following jobs were run on top of the branch https://github.com/mbta/actions/tree/kf/test/circuit-breaker-deploys which included work from #47. I can rerun all these jobs without #47, but I believe that there are no logic changes in #47 that would meaningfully affect this PR.

### Before this PR
#### Skate, workflow FP
For completeness, here's a [false positive workflow success when the circuit breaker actually stopped the deploy](https://github.com/mbta/skate/actions/runs/8800991063)

### After this PR
#### Circuit Breaker Jobs (Skate)
##### Successful deploy:
> [Deployment complete.](https://github.com/mbta/skate/actions/runs/8833919245/job/24254398210#step:9:1026)

##### Failing deploy, health check failure
> [The deployment failed because one or more containers stopped running. The reasons given were:
Task failed ELB health checks in (target-group arn:aws:elasticloadbalancing:us-east-1:***:targetgroup/skate-dev-green-alb/\*\*\*)](https://github.com/mbta/skate/actions/runs/8833588623/job/24253247822#step:9:1111)

##### Failing deploy, application failure
> [The deployment failed because one or more containers stopped running. The reasons given were:
Essential container in task exited](https://github.com/mbta/skate/actions/runs/8834107261/job/24255014396#step:9:941)

#### Non-Circuit Breaker Jobs (Arrow)
##### Successful deploy:
> [Deployment complete.](https://github.com/mbta/arrow/actions/runs/8833181657/job/24251940955#step:4:876)

##### Unsuccessful deploy, health check failure:
> [The deployment failed because one or more containers stopped running. The reasons given were:
Task failed ELB health checks in (target-group arn:aws:elasticloadbalancing:us-east-1:***:targetgroup/arrow-dev-alb/\*\*\*)](https://github.com/mbta/arrow/actions/runs/8833534327/job/24253074346#step:4:932)

##### Unsuccessful deploy, application failure
> [The deployment failed because one or more containers stopped running. The reasons given were:
Essential container in task exited](https://github.com/mbta/arrow/actions/runs/8833526799/job/24253050024#step:4:860)

</details>


<details>
<summary>

## Future work

</summary>

I think that `deploy.sh` should keep track of the deploy id's and get the deploys from the `id` value, instead of the `status`.
```
new_deployment="$(echo "${service_status}" | jq -r '.services[0].deployments[] | select(.status == "PRIMARY")')"
```
Would become
```
new_deployment="$(echo "${service_status}" | jq -r '.services[0].deployments[] | select(.id == $deployment_id)')" --arg deployment_id $new_deployment_id
```

But I don't think I understand other team's use cases enough to know if there's always a singular new deployment ID for each workflow run.

---

It'd also be _neat_ to use `aws ecs wait services-stable` but it doesn't give regular updates on `stdout` or `stderr` :/

</details>

---

Asana Ticket:
- [⚙️ Fail GitHub deploy script when the circuit breaker failsa](https://app.asana.com/0/1148853526253420/1207138670752006/f)
- [Add circuit breaker support to ECS deployment](https://app.asana.com/0/1113179098808463/1199587799058293/f)
