### PR TITLE
fix(deploy-ecs/deploy.sh): missed rename of `rollout_state` => `rollout_status`

### DIFF
--- a/deploy-ecs/deploy.sh
+++ b/deploy-ecs/deploy.sh
@@ -42,7 +42,7 @@ function check_deployment_complete() {
   printf \
     "id: %s, Status: %+12s, Running: %3d, Failed: %3d, Pending: %3d, Desired: %3d\n" \
     "${id}" \
-    "${rollout_state}" \
+    "${rollout_status}" \
     "${running_count}" \
     "${failed_count}" \
     "${pending_count}" \


### PR DESCRIPTION
Missed a variable rename in the original PR #47 

https://mbta.slack.com/archives/GP5QJM98A/p1714072872999369?thread_ts=1714066291.193969&cid=GP5QJM98A

## Examples
Failing deploy due to missing variable: 
- https://github.com/mbta/skate/actions/runs/8837990107/job/24268816484#step:9:934

Fixed deploy (failing for application reasons)
- https://github.com/mbta/skate/actions/runs/8838299876/job/24269110006