### PR TITLE
ci: check that .sh files have chmod +x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,21 @@
-name: Validate YAML
+name: CI
 
 on:  # Triggers the workflow on push or pull request events
   push:
   pull_request:
 
 jobs:
-  build:
+  yaml:
     name: Validate YAML actions
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
       - run: yamllint -f parsable .
+  chmod:
+    name: Ensure .sh files have chmod +x
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - run: find . -name '*.sh' \! -executable | (! grep .)


### PR DESCRIPTION
This shell one-liner was an adventure to find, and it doesn't help that BSD `find` doesn't have the `-executable` flag but GNU `find` doesn't support the same `-perm +u+x` that BSD `find` does, but it looks like it should print the scripts which are not +x and fail if any of them exist.

The trick is that `grep` succeeds as long as it finds something, so `grep .` will print every line and succeed if there was a line, and `! grep .` will print every line and fail if there was a line.