### PR TITLE
ci: add shellcheck for shell scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,12 @@ jobs:
       - uses: actions/checkout@v4
       - run: yamllint -f parsable .
   chmod:
-    name: Ensure .sh files have chmod +x
+    name: Check shell scripts
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
-      - run: find . -name '*.sh' \! -executable | (! grep .)
+      - name: shellcheck
+        run: find . -name '*.sh' | xargs shellcheck -S warning
+      - name: Ensure .sh files have chmod +x
+        run: find . -name '*.sh' \! -executable | (! grep .)


### PR DESCRIPTION
Since we don't manage yamllint via asdf, it seems defensible to not manage shellcheck via asdf here, either.