### PR TITLE
feat(deploy-ecs): add groups to log output

### DIFF
--- a/deploy-ecs/deploy.sh
+++ b/deploy-ecs/deploy.sh
@@ -81,7 +81,7 @@ if [ "${REQUIRES_SECRETS}" = true ] && (echo "${newcontainers}" | jq '.[0] | .se
   exit 1
 fi
 
-echo "Publishing new ${LAUNCH_TYPE} task definition."
+echo "::group::Publishing new ${LAUNCH_TYPE} task definition."
 if [ "${LAUNCH_TYPE}" = "FARGATE" ]; then
   aws ecs register-task-definition \
     --family "${ECS_TASK_DEF}" \
@@ -103,10 +103,11 @@ elif [ "${LAUNCH_TYPE}" = "EC2" ] || [ "${LAUNCH_TYPE}" = "EXTERNAL" ]; then
     --volumes "$(echo "${taskdefinition}" | jq '.taskDefinition.volumes')" \
     --placement-constraints "$(echo "${taskdefinition}" | jq '.taskDefinition.placementConstraints')"
 else
+  echo "::endgroup::"
   echo "Error: expected 'FARGATE', 'EC2', or 'EXTERNAL' launch-type, got ${LAUNCH_TYPE}"
   exit 1
 fi
-
+echo "::endgroup::" # publishing task definition
 
 newrevision="$(aws ecs describe-task-definition --task-definition "${ECS_TASK_DEF}" | \
   jq -r '.taskDefinition.revision')"

--- a/deploy-ecs/deploy.sh
+++ b/deploy-ecs/deploy.sh
@@ -152,7 +152,7 @@ while [ "${deployment_finished}" = "false" ]; do
 done
 echo "::endgroup::"
 
-# confirm that the old deployment is torn down
+echo "::group::confirm that the old deployment is torn down"
 teardown_finished=false
 while [ "${teardown_finished}" = "false" ]; do
   # get the service details
@@ -181,5 +181,6 @@ while [ "${teardown_finished}" = "false" ]; do
     sleep 5
   fi
 done
+echo "::endgroup::"
 
 echo "Done."

--- a/deploy-ecs/deploy.sh
+++ b/deploy-ecs/deploy.sh
@@ -117,7 +117,7 @@ echo "::group::Updating service ${ECS_SERVICE} to use task definition ${newrevis
 aws ecs update-service --cluster="${ECS_CLUSTER}" --service="${ECS_SERVICE}" --task-definition "${ECS_TASK_DEF}:${newrevision}"
 echo "::endgroup::"
 
-echo "::group::Wait for the new clister to stabilize"
+echo "::group::Wait for the new cluster to stabilize"
 deployment_finished=false
 while [ "${deployment_finished}" = "false" ]; do
   # get the service details

--- a/deploy-ecs/deploy.sh
+++ b/deploy-ecs/deploy.sh
@@ -113,8 +113,9 @@ newrevision="$(aws ecs describe-task-definition --task-definition "${ECS_TASK_DE
   jq -r '.taskDefinition.revision')"
 
 # redeploy the cluster
-echo "Updating service ${ECS_SERVICE} to use task definition ${newrevision}..."
+echo "::group::Updating service ${ECS_SERVICE} to use task definition ${newrevision}..."
 aws ecs update-service --cluster="${ECS_CLUSTER}" --service="${ECS_SERVICE}" --task-definition "${ECS_TASK_DEF}:${newrevision}"
+echo "::endgroup::"
 
 # monitor the cluster for status
 deployment_finished=false


### PR DESCRIPTION
I was looking for a way to compact parts of the log output that I appreciate having, but don't always need to look at. This takes some of the discrete steps within deploy-ecs and groups them in the github actions log.

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#grouping-log-lines


## Example Output
1. https://github.com/mbta/skate/actions/runs/8854493556/job/24317639332#step:9:994
![image](https://github.com/mbta/actions/assets/6913198/b0823fdf-1072-42d3-a398-b5e41542bdc3)
