### PR TITLE
Convert output from list-tasks to quoted and space separated list

### DIFF
--- a/deploy-ecs/deploy.sh
+++ b/deploy-ecs/deploy.sh
@@ -131,12 +131,17 @@ while [ "${deployment_finished}" = "false" ]; do
     # extract deployment id
     new_deployment_id="$(echo "${new_deployment}" | jq -r '.id')"
     # find any tasks that may have stopped unexpectedly
-    stopped_tasks="$(aws ecs list-tasks --cluster "${ECS_CLUSTER}" --started-by "${new_deployment_id}" --desired-status "STOPPED" | jq -r '.taskArns')"
-    stopped_task_count="$(echo "${stopped_tasks}" | jq -r 'length')"
+    # this should provide a list of arns (if any) that are quoted and space separated
+    # i.e. "arn:aws:ecs:us-west-2:123456789012:task/a1b2c3d4-5678-90ab-cdef-11111EXAMPLE" "arn:aws:ecs:us-west-2:123456789012:task/a1b2c3d4-5678-90ab-cdef-22222EXAMPLE"
+    stopped_tasks="$(aws ecs list-tasks --cluster "${ECS_CLUSTER}" --started-by "${new_deployment_id}" --desired-status "STOPPED" | jq -r '.taskArns[] | "\"\(. )\""' | tr '\n' ' ')"
+
+    # count number of quotes and divide by two
+    stopped_task_count=$(echo "$stopped_tasks" | grep -o '\"' | wc -l)
+    stopped_task_count=$((stopped_task_count / 2))
+
     if [ "${stopped_task_count}" -gt "0" ]; then
       # if there are stopped tasks, print the reason they stopped and then exit
-      stopped_task_list="$(echo "${stopped_tasks}" | jq -r 'join(",")')"
-      stopped_reasons="$(aws ecs describe-tasks --cluster "${ECS_CLUSTER}" --tasks "${stopped_task_list}" | jq -r '.tasks[].stoppedReason')"
+      stopped_reasons="$(aws ecs describe-tasks --cluster "${ECS_CLUSTER}" --tasks "${stopped_tasks}" | jq -r '.tasks[].stoppedReason')"
       echo "The deployment failed because one or more containers stopped running. The reasons given were:"
       echo "${stopped_reasons}"
       exit 1


### PR DESCRIPTION
In my commit comment I said "comma separated". I meant to say "space separated".

Asana task:
https://app.asana.com/0/1113545750913664/1204864778315054

list-tasks output piped into jq was creating a comma separated list of ARNs.  describe-tasks however requires a list of ARNs that are quoted and space delineated.  So instead of ARN001,ARN002 we need "ARN001" "ARN002"  as input to describe-tasks.

I'm adding two shell script samples into this PR description demonstrating old and new method.  Feel free to download and run them.

[Archive.zip](https://github.com/mbta/actions/files/15179111/Archive.zip)
