### PR TITLE
fix(deploy-ecs): default to COMPLETE if `rolloutState` isn't present

### DIFF
--- a/deploy-ecs/deploy.sh
+++ b/deploy-ecs/deploy.sh
@@ -30,7 +30,7 @@ function check_deployment_complete() {
   id="$(echo "${deployment_details}" | jq -r '.id')"
 
   # get rollout state
-  rollout_status="$(echo "${deployment_details}" | jq -r '.rolloutState')"
+  rollout_status="$(echo "${deployment_details}" | jq -r '.rolloutState // "COMPLETED"')"
 
   # get current task counts
   desired_count="$(echo "${deployment_details}" | jq -r '[.desiredCount, 1] | max')"


### PR DESCRIPTION
EC2 deploy status look like this:

```json
{
  "id": "ecs-svc/<id>",
  "status": "PRIMARY",
  "taskDefinition": "arn:aws:ecs:us-east-1:<account>:task-definition/<service>:<version>",
  "desiredCount": 1,
  "pendingCount": 0,
  "runningCount": 1,
  "failedTasks": 0,
  "createdAt": "2024-05-13T08:37:58.664000-04:00",
  "updatedAt": "2024-05-13T08:37:58.664000-04:00",
  "launchType": "EC2"
}
```

Since there's no `rolloutState` here, we default to `COMPLETED` and rely on the `runningCount` equaling the `desiredCount`

Failed deploy: https://github.com/mbta/tablespoon/actions/runs/8991294003 (status is null)
Successful deploy: https://github.com/mbta/tablespoon/actions/runs/9063171014 (status defaults to COMPLETED)