### PR TITLE
FEAT: Allow 0 desiredCount for deploy-ecs action

### DIFF
--- a/deploy-ecs/action.yml
+++ b/deploy-ecs/action.yml
@@ -28,6 +28,10 @@ inputs:
     description: ECS launch type ("FARGATE", "EC2", or "EXTERNAL")
     required: false
     default: 'FARGATE'
+  allow-zero-desired:
+    description: Whether the deploy allows the ECS desiredCount to be 0 (expects "true" or "false")
+    required: false
+    default: 'false'
 runs:
   using: composite
   steps:
@@ -47,3 +51,4 @@ runs:
         DOCKER_TAG: ${{ inputs.docker-tag }}
         REQUIRES_SECRETS: ${{ inputs.requires-secrets }}
         LAUNCH_TYPE: ${{ inputs.launch-type }}
+        ALLOW_ZERO_DESIRED: ${{ inputs.allow-zero-desired }}

--- a/deploy-ecs/deploy.sh
+++ b/deploy-ecs/deploy.sh
@@ -20,6 +20,7 @@ function check_deployment_complete() {
   local deployment_details
   local id
   local rollout_status
+  local min_desired_count
   local desired_count
   local pending_count
   local running_count
@@ -32,8 +33,14 @@ function check_deployment_complete() {
   # get rollout state
   rollout_status="$(echo "${deployment_details}" | jq -r '.rolloutState // "COMPLETED"')"
 
+  # check if 0 desiredCount is allowed
+  min_desired_count=1
+  if [ "${ALLOW_ZERO_DESIRED}" = true ]; then
+    min_desired_count=0
+  fi
+
   # get current task counts
-  desired_count="$(echo "${deployment_details}" | jq -r '[.desiredCount, 1] | max')"
+  desired_count="$(echo "${deployment_details}" | jq -r '[.desiredCount, '"${min_desired_count}"' ] | max')"
   pending_count="$(echo "${deployment_details}" | jq -r '.pendingCount')"
   running_count="$(echo "${deployment_details}" | jq -r '.runningCount')"
   failed_count="$(echo "${deployment_details}" | jq -r '.failedTasks')"


### PR DESCRIPTION
The LAMP team does not always have all of our ECS instances running at the time of a deploy, meaning the ECS deployment details `desiredCount` can be set to 0. 

This change allows a `desiredCount` value of 0 through the use of a boolean input flag `allow-zero-desired` input on the deploy-ecs action. By default this flag is set to `false` which should have zero impact on existing users of this action. 