### PR TITLE
feat: add an output for the tag suffix

### DIFF
--- a/build-push-ecr/action.yml
+++ b/build-push-ecr/action.yml
@@ -27,6 +27,9 @@ outputs:
   docker-tag:
     description: Docker Tag
     value: ${{ steps.docker.outputs.tag }}
+  docker-tag-suffix:
+    description: Docker Tag Suffix (the part after the :)
+    value: ${{ steps.docker.outputs.tag-suffix }}
 runs:
   using: composite
   steps:
@@ -36,7 +39,10 @@ runs:
         role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: ${{ inputs.aws-region }}
         mask-aws-account-id: true
-    - run: echo "tag=${{ inputs.docker-repo }}:git-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+    - run: |
+        short_sha=$(git rev-parse --short HEAD)
+        echo "tag=${{ inputs.docker-repo }}:git-${short_sha}" >> $GITHUB_OUTPUT
+        echo "tag-suffix=git-${short_sha}" >> $GITHUB_OUTPUT
       id: docker
       shell: bash
     - run: >


### PR DESCRIPTION
This allows us to avoid using the DOCKER_REPO secret in the output.

Supersedes #58 