### PR TITLE
FIX: import path for shared/register_task_options script

### DIFF
--- a/deploy-ecs/deploy.sh
+++ b/deploy-ecs/deploy.sh
@@ -16,7 +16,7 @@ set -e -u
 # - DOCKER_TAG
 
 # makes 'build_register_task_options' function available, produces 'reg_options' global var
-. $(dirname $0)/../shared/register_task_options.sh
+. "$(dirname $0)"/../shared/register_task_options.sh
 reg_options=() # returned as global by build_register_task_options
 
 function check_deployment_complete() {

--- a/deploy-ecs/deploy.sh
+++ b/deploy-ecs/deploy.sh
@@ -16,7 +16,7 @@ set -e -u
 # - DOCKER_TAG
 
 # makes 'build_register_task_options' function available, produces 'reg_options' global var
-. ../shared/register_task_options.sh
+. $(dirname $0)/../shared/register_task_options.sh
 reg_options=() # returned as global by build_register_task_options
 
 function check_deployment_complete() {

--- a/deploy-scheduled-ecs/deploy.sh
+++ b/deploy-scheduled-ecs/deploy.sh
@@ -18,7 +18,7 @@ set -e -u
 # - DOCKER_TAG: tag for docker image to use in new task definition
 
 # makes 'build_register_task_options' function available, produces 'reg_options' global var
-. $(dirname $0)/../shared/register_task_options.sh
+. "$(dirname $0)"/../shared/register_task_options.sh
 reg_options=() # returned as global by build_register_task_options
 
 # set default region so we don't have to specify --region everywhere

--- a/deploy-scheduled-ecs/deploy.sh
+++ b/deploy-scheduled-ecs/deploy.sh
@@ -18,7 +18,7 @@ set -e -u
 # - DOCKER_TAG: tag for docker image to use in new task definition
 
 # makes 'build_register_task_options' function available, produces 'reg_options' global var
-. ../shared/register_task_options.sh
+. $(dirname $0)/../shared/register_task_options.sh
 reg_options=() # returned as global by build_register_task_options
 
 # set default region so we don't have to specify --region everywhere


### PR DESCRIPTION
Import updated to use relative file path. 

Tested on LAMP action: 
https://github.com/mbta/lamp/actions/runs/11597958292/job/32292698518