### PR TITLE
FEAT: new ecs-run-task action for starting EventBridge tasks via GHA

### DIFF
--- a/ecs-run-task/action.yaml
+++ b/ecs-run-task/action.yaml
@@ -1,0 +1,34 @@
+name: Manually Run ECS Task
+description: Run an existing task from an AWS Service and Cluster
+
+inputs:
+  role-to-assume:
+    description: IAM role
+    required: true
+  aws-region:
+    description: AWS region to use
+    required: true
+    default: us-east-1
+  cluster:
+    description: ECS Cluster for Service
+    required: true
+  service:
+    description: ECS Service for task to run
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Setup AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ inputs.role-to-assume }}
+        aws-region: ${{ inputs.aws-region }}
+        mask-aws-account-id: true
+    - name: Start ECS Task
+      run: ${{ github.action_path }}/run_task.sh
+      shell: bash
+      env:
+        AWS_REGION: ${{ inputs.aws-region }}
+        CLUSTER: ${{ inputs.cluster }}
+        SERVICE: ${{ inputs.service }}

--- a/ecs-run-task/run_task.sh
+++ b/ecs-run-task/run_task.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e -u
+
+# Run an ECS Task from the provided CLUSTER and SERVICE
+#
+# This actions is generally used for ad-hoc launching of ECS tasks that are scheduled with EventBridge
+# Will launch 1 instance of latest SERVICE task 
+# with launch-type and network-configuration found in describe-services call
+#
+# This action requires the GHA IAM role to have the following permissions:
+# ecs:RunTask on SERVICE task-definition
+# ecs:DescribeServices on CLUSTER service
+
+# required environment varialbes
+# - AWS_REGION
+# - CLUSTER
+# - SERVICE
+
+# Get the service description for the task.
+echo "Retrieving service description for SERVICE:${SERVICE} in CLUSTER:${CLUSTER}"
+service_description=$(aws ecs describe-services \
+  --cluster $CLUSTER \
+  --service $SERVICE \
+  --query services[0])
+
+launch_type="$(echo "${service_description}" | jq -r '.launchType')"
+net_config="$(echo "${service_description}" | jq -r '.networkConfiguration')"
+
+echo "Running latest version of '${SERVICE}' task, in '${CLUSTER}' cluster."
+echo "launch-type=${launch_type}"
+echo "network-configuration=${net_config}"
+
+# Run the ECS task
+aws ecs run-task \
+  --cluster $CLUSTER \
+  --task-definition $SERVICE \
+  --launch-type "${launch_type}" \
+  --count 1 \
+  --network-configuration "${net_config}"


### PR DESCRIPTION
The change adds a new action that allows an ECS task, that is usually run via EventBridge scheduling, to be manually started via Github Action. 

A version of this action is already in use in the lamp repository (https://github.com/mbta/lamp/tree/main/.github/actions/run_task). This will also be incorporated into the dmap-import application, so it seemed like a good time to add it to the `actions` repo. 

The action works by accepting a `CLUSTER` and `SERVICE` env var. Using the defined `CLUSTER` and `SERVICE`, information is pulled from the `aws ecs describe-services` command and used to trigger an `aws ecs run-task` command.  The latest task definition, for the defined `SERVICE` will be triggered via `run-task`.