### PR TITLE
chore: split linter into two actions

### DIFF
--- a/lint-python-scripts/action.yml
+++ b/lint-python-scripts/action.yml
@@ -1,0 +1,8 @@
+name: Lint Python Scripts
+description: Lint python scripts using flake8
+runs:
+  using: composite
+  steps:
+    - name: Run flake8
+      shell: bash
+      run: ${{ github.action_path }}/lint-python-scripts.sh

--- a/lint-python-scripts/lint-python-scripts.sh
+++ b/lint-python-scripts/lint-python-scripts.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# lint python scripts in bin/
+
+set -e
+
+# lint python scripts
+python_scripts="$(grep -rIl '^#!.*python' ./bin)" \
+    || echo "No python scripts found in ./bin."
+for script in ${python_scripts}; do
+    echo "Linting ${script}..."
+    flake8 "${script}"
+done

--- a/lint-shell-scripts/action.yml
+++ b/lint-shell-scripts/action.yml
@@ -1,8 +1,8 @@
-name: Lint Scripts
+name: Lint Shell Scripts
 description: Lint bash scripts using shellcheck
 runs:
   using: composite
   steps:
     - name: Run shellcheck
       shell: bash
-      run: ${{ github.action_path }}/lint-scripts.sh
+      run: ${{ github.action_path }}/lint-shell-scripts.sh

--- a/lint-shell-scripts/lint-shell-scripts.sh
+++ b/lint-shell-scripts/lint-shell-scripts.sh
@@ -1,16 +1,8 @@
 #!/usr/bin/env bash
 
-# lint all scripts in bin/
+# lint shell scripts in bin/ and .github/scripts/
 
 set -e
-
-# lint python scripts
-python_scripts="$(grep -rIl '^#!.*python' ./bin)" \
-    || echo "No python scripts found in ./bin."
-for script in ${python_scripts}; do
-    echo "Linting ${script}..."
-    flake8 "${script}"
-done
 
 # lint bash scripts
 bash_scripts="$(grep -rIl '^#!.*bash' ./bin)" \


### PR DESCRIPTION
## Summary
This PR splits the `lint-scripts` action into separate actions--one for python and one for shell scripts. Hat tip to @ianwestcott for the suggestion!

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212584361303927