### PR TITLE
chore: turn off output for ECS register-task-definition

### DIFF
--- a/deploy-ecs/deploy.sh
+++ b/deploy-ecs/deploy.sh
@@ -117,7 +117,7 @@ newrevision="$(aws ecs describe-task-definition --task-definition "${ECS_TASK_DE
 
 # redeploy the cluster
 echo "::group::Updating service ${ECS_SERVICE} to use task definition ${newrevision}..."
-aws ecs update-service --cluster="${ECS_CLUSTER}" --service="${ECS_SERVICE}" --task-definition "${ECS_TASK_DEF}:${newrevision}"
+aws ecs update-service --cluster="${ECS_CLUSTER}" --service="${ECS_SERVICE}" --task-definition "${ECS_TASK_DEF}:${newrevision}" --output off
 echo "::endgroup::"
 
 echo "::group::Wait for the new cluster to stabilize"

--- a/deploy-ecs/deploy.sh
+++ b/deploy-ecs/deploy.sh
@@ -95,7 +95,7 @@ fi
 echo "::group::Publishing new ${LAUNCH_TYPE} task definition."
 if [ "${LAUNCH_TYPE}" = "FARGATE" ]; then
   build_register_task_options "${taskdefinition}" "${newcontainers}"
-  aws ecs register-task-definition "${reg_options[@]}"
+  aws ecs register-task-definition "${reg_options[@]}" --output off
 elif [ "${LAUNCH_TYPE}" = "EC2" ] || [ "${LAUNCH_TYPE}" = "EXTERNAL" ]; then
   aws ecs register-task-definition \
     --family "${ECS_TASK_DEF}" \
@@ -103,7 +103,8 @@ elif [ "${LAUNCH_TYPE}" = "EC2" ] || [ "${LAUNCH_TYPE}" = "EXTERNAL" ]; then
     --execution-role-arn "$(echo "${taskdefinition}" | jq -r '.taskDefinition.executionRoleArn')" \
     --container-definitions "${newcontainers}" \
     --volumes "$(echo "${taskdefinition}" | jq '.taskDefinition.volumes')" \
-    --placement-constraints "$(echo "${taskdefinition}" | jq '.taskDefinition.placementConstraints')"
+    --placement-constraints "$(echo "${taskdefinition}" | jq '.taskDefinition.placementConstraints')" \
+    --output off
 else
   echo "::endgroup::"
   echo "Error: expected 'FARGATE', 'EC2', or 'EXTERNAL' launch-type, got ${LAUNCH_TYPE}"


### PR DESCRIPTION
**Asana issue**: [deploy-ecs action exposing task definition details](https://app.asana.com/1/15492006741476/project/1200506724882024/task/1202461323639840?focus=true)
If I am understanding the [CLI docs](https://docs.aws.amazon.com/cli/latest/reference/ecs/register-task-definition.html) correctly, this added argument will turn off the CLI output that's currently exposing our entire task definition!

_A consideration_: what if deployers depend on this output, to ensure that they're deploying the right thing?
To which I say... this doesn't seem likely, and on the rare occasion this occurs they can log into the AWS console and see for themselves. 

Open to hearing other thoughts.