### PR TITLE
chore: upgrade configure-aws-credentials to v6 ec61189

### DIFF
--- a/build-push-ecr/action.yml
+++ b/build-push-ecr/action.yml
@@ -34,7 +34,7 @@ runs:
   using: composite
   steps:
     - name: Setup AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37
       with:
         role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: ${{ inputs.aws-region }}

--- a/deploy-ecs/action.yml
+++ b/deploy-ecs/action.yml
@@ -36,7 +36,7 @@ runs:
   using: composite
   steps:
     - name: Setup AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37
       with:
         role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: ${{ inputs.aws-region }}

--- a/ecs-run-task/action.yaml
+++ b/ecs-run-task/action.yaml
@@ -20,7 +20,7 @@ runs:
   using: composite
   steps:
     - name: Setup AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37
       with:
         role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: ${{ inputs.aws-region }}


### PR DESCRIPTION
Asana Task: [configure-aws-credentials@v4 may break on June 2, 2026](https://app.asana.com/1/15492006741476/project/1113179098808463/task/1214092605392805)

Glides actions are reporting this error from GitHub, coming from `deploy-ecs`:

> Warning: Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: aws-actions/configure-aws-credentials@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

So I'm updating all of:
- build-push-ecr
- deploy-ecs
- ecs-run-task